### PR TITLE
Add NGINX file upload size annotations

### DIFF
--- a/values-custom.yaml
+++ b/values-custom.yaml
@@ -34,6 +34,10 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /
+
+    # match the default size of the nlweb-backend value
+    nginx.ingress.kubernetes.io/proxy-body-size: 250m
+
     alb.ingress.kubernetes.io/scheme: "internet-facing"
     alb.ingress.kubernetes.io/backend-protocol: "HTTP"
   ### TLS configuration


### PR DESCRIPTION
Working with Laurent C today, we identified that by default the NGINX Ingress Controller only allows file uploads of 1mb, which prevents the back-end from receiving files larger than that.

The simplest solution is to add an NGINX annotation 'nginx.ingress.kubernetes.io/proxy-body-size: 250m' that matches what is in the backend environment variables.

Though this allows all connections to the LB and ingress to do this, not just specifically for the files endpoint, the other services are configured to not allow large bodies anyway, so this is an acceptable short-term workaround.