### PR TITLE
FIX: mongo db port set to 0 was considered as empty value and was def…

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: MONGODB_HOST
               value: {{ .Values.neoload.configuration.backend.mongo.host | required "MongoDb host (--set neoload.configuration.backend.mongo.host=YOUR_MONGODB_HOST) value is required." | quote }}
             - name: MONGODB_PORT
-              value: {{ default 27017 .Values.neoload.configuration.backend.mongo.port | quote }}
+              value: {{ if kindIs "invalid" .Values.neoload.configuration.backend.mongo.port }}{{ 27017 | quote }}{{ else }}{{ .Values.neoload.configuration.backend.mongo.port | quote }}{{ end }}
             {{- if .Values.mongodb.usePassword }}
             - name: MONGODB_LOGIN
               valueFrom:


### PR DESCRIPTION
FIX: mongo db port set to 0 was considered as empty value and was defaulting to 27017.
0 is now considered as a valid value.

References:
https://github.com/helm/helm/issues/3164
https://github.com/Masterminds/sprig/blob/master/docs/defaults.md