### PR TITLE
[LOAD-24493] - Securing JSESSIONID cookie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Parameter | Description | Default
 `neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `neoload.configuration.frontend.java.xmx` | Java JVM Max heap size for the frontend | `1200m`
-`neoload.configuration.frontend.secureSessionCookie` | Put secure flag on JSESSIONID cookie | `true` if `ingress.tls` is preent, else `false`
+`neoload.configuration.frontend.secureSessionCookie` | Put secure flag on JSESSIONID cookie | `true` if `ingress.tls` is present, else `false`
 `neoload.configuration.frontend.others` | Custom frontend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `mongodb.usePassword` | Set to false if your MongoDB connection doesn't require authentication | `true`

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Parameter | Description | Default
 `neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `neoload.configuration.frontend.java.xmx` | Java JVM Max heap size for the frontend | `1200m`
+`neoload.configuration.frontend.secureSessionCookie` | Put secure flag on JSESSIONID cookie | `true` if `ingress.tls` is preent, else `false`
 `neoload.configuration.frontend.others` | Custom frontend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `mongodb.usePassword` | Set to false if your MongoDB connection doesn't require authentication | `true`
@@ -344,8 +345,13 @@ neoload:
         ENV_VAR_2: variable2
 
 ```
+## External TLS termination
 
-## TLS
+>**Caution**: If you choose to not handle TLS through the ingress feature, we recommend, for security reason, to set the >value of the property `neoload.configuration.frontend.secureSessionCookie` to `true`.
+>
+>This will put a secure flag on the JSESSIONID cookie (the Java Servlet session identifier). 
+
+## Cluster TLS termination
 
 To enable TLS and access NeoLoad Web via https, the parameters :
 

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -60,6 +60,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            {{- if and (not .Values.ingress.tls) (not .Values.neoload.configuration.frontend.secureSessionCookie) }}
+            - name: JESSIONID_SECURE_FLAG
+              value: "false"
+            {{- end }}
           ports:
             - name: webapp
               containerPort: 9090


### PR DESCRIPTION
By default it is true if ingress.tls is defined.
It is also possible to force the secure flag on JSESSIONID cookie (if TLS is not handled by ingress for instance).