### PR TITLE
[LOAD-24493] - Add secure flag to JSESSIONID

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Parameter | Description | Default
 `resources.frontend.limits.cpu` | CPU resource limit for the frontend | `2`
 `resources.frontend.limits.memory` | Memory resource limit for the frontend | `2Gi`
  |  | 
+`neoload.configuration.externalTlsTermination` | Must be set to true if TLS termination is [handled by your own way](#external-tls-termination).  | `false`
+ |  | 
 `neoload.configuration.backend.mongo.host` | MongoDB host | 
 `neoload.configuration.backend.mongo.port` | MongoDB port | `27017`
 `neoload.configuration.backend.mongo.poolSize` | MongoDB pool size | `50`
@@ -346,6 +348,11 @@ neoload:
 ```
 
 ## TLS
+If you want to secure NeoLoad Web through TLS, you should either:
+ - configure [TLS at ingress level](#ingress-tls-termination)
+ - handle [TLS termination on front of the Ingress controller](#external-tls-termination)
+
+### Ingress TLS termination
 
 To enable TLS and access NeoLoad Web via https, the parameters :
 
@@ -354,22 +361,31 @@ To enable TLS and access NeoLoad Web via https, the parameters :
 
 > **Caution**: Ingresses support multiple TLS mapped to respective hosts and paths. This feature is not supported for NeoLoad Web, i.e. exactly zero or one TLS configuration is expected.
 
-### Using an existing tls secret
+#### Using an existing TLS secret
 
 Simply refer to your secret in the `ingress.tls[0].secretName` parameter, and leave both `ingress.tls[0].secretCertificate` and `ingress.tls[0].secretKey` empty.
 
-### Creating a new tls secret
+#### Creating a new TLS secret
 
-#### Provide a certificate and a private key
+##### Provide a certificate and a private key
 
 Use the following documentation or use your own means to provide both a certificate and a private key.
 
 - [Kubernetes TLS Secret generation documentation](https://kubernetes.github.io/ingress-nginx/user-guide/tls/)
 
-#### Add these to your custom values file
+##### Add these to your custom values file
 
 Copy the content of the files into the `ingress.tls[0].secretCertificate` and `ingress.tls[0].secretKey` parameters.
 
-#### Specify your new tls secret name
+##### Specify your new TLS secret name
 
-Set a name for your new tls secret name into the `ingress.tls[0].secretName` parameter.
+Set a name for your new TLS secret name into the `ingress.tls[0].secretName` parameter.
+
+### External TLS termination
+
+>**Caution**: 
+> If you choose to handle TLS on front of the Ingress controller, we recommend, for security reason, to set the 
+> value of the property `neoload.configuration.externalTlsTermination` to `true`.
+>
+> It will define URLs to NeoLoad Web to use `https://` protocol. 
+> And it will ensure that NeoLoad Web flags the JSESSIONID cookie as `secure`.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -107,10 +107,8 @@ Helper - getScheme
 */}}
 {{- define "nlweb.helpers.getScheme" -}}
     http
-    {{- if .Values.ingress.enabled -}}
-    {{- if .Values.ingress.tls -}}
+    {{- if or (and .Values.ingress.enabled .Values.ingress.tls) (eq (.Values.neoload.configuration.externalTlsTermination | toString) "true") -}}
         s
-    {{- end -}}
     {{- end -}}
     ://
 {{- end -}}

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -54,9 +54,17 @@ spec:
               value: {{ .Values.neoload.configuration.misc.trackingUrl | quote }}
             {{- end -}}
             {{- end }}
+<<<<<<< HEAD
             {{- if eq ((include "nlweb.helpers.getScheme" .) | toString) "http://" }}
             - name: JESSIONID_SECURE_FLAG
               value: "false"
+=======
+            - name: JSESSIONID_SECURE_FLAG
+            {{- if eq ((include "nlweb.helpers.getScheme" .) | toString) "http://" }}
+              value: "false"
+            {{- else }}
+              value: "true"
+>>>>>>> a4f9499 ([LOAD-24493] - Add secure flag to JSESSIONID)
             {{- end }}
             {{- if .Values.neoload.configuration.frontend.others }}
             {{- range $name, $value := .Values.neoload.configuration.frontend.others }}

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.neoload.configuration.misc.trackingUrl | quote }}
             {{- end -}}
             {{- end }}
+            {{- if eq ((include "nlweb.helpers.getScheme" .) | toString) "http://" }}
+            - name: JESSIONID_SECURE_FLAG
+              value: "false"
+            {{- end }}
             {{- if .Values.neoload.configuration.frontend.others }}
             {{- range $name, $value := .Values.neoload.configuration.frontend.others }}
             - name: {{ $name }}


### PR DESCRIPTION
Why ?
Starting with 2.11, NLW will, by default, put the secure flag on the cookie.

How ?
Helm chart will determine if NLW is behind TLS or not.
If yes, nothing is done since NLW will automatically add the flag.
If not, the environment variable JESSIONID_SECURE_FLAG will be set to false, forcing NLW to not add the secure flag.
I also added a new value (neoload.configuration.externalTlsTermination) to let user specify that NLW will be accessed through TLS layer and that TLS termination will not be handled by the ingress configuration (value `.Values.ingress.enabled` and `.Values.ingress.tls`).