### PR TITLE
FIX #18 - Do not prefix TLS Secret name with release name to avoid mi…

### DIFF
--- a/templates/secrets-tls.yaml
+++ b/templates/secrets-tls.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" $fullName $secretName | required $nameRequiredMessage }}
+  name: {{ $secretName | required $nameRequiredMessage }}
   namespace: {{ $namespace }}  
   labels:
     {{- $labels | nindent 4 }}


### PR DESCRIPTION
…smatch when referencing it in Ingress definition.

We cannot add the release name on Ingress definition because the secret can be provided by user.