### PR TITLE
Use a random and unique (per installation) value for INTERNAL_TOKEN_SECRET.

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -25,6 +25,13 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Build the name of the secrets-key secret.
+*/}}
+{{- define "nlweb.secrets.key.name" -}}
+{{- printf "%s-%s" (include "nlweb.fullname" .) "key-secret" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "nlweb.chart" -}}

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -75,8 +75,13 @@ spec:
             - name: NLWEB_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nlweb.fullname" . }}-key-secret
+                  name: {{ include "nlweb.secrets.key.name" . }}
                   key: nlwSecretKey
+            - name: INTERNAL_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nlweb.secrets.key.name" . }}
+                  key: internalTokenSecret
             - name: DEPLOYMENT_TYPE
               value: "helm/kubernetes"
             - name: HAZELCAST_KUBERNETES_RESOLVE_NOT_READY_ADDRESSES

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -54,6 +54,11 @@ spec:
               value: {{ .Values.neoload.configuration.misc.trackingUrl | quote }}
             {{- end -}}
             {{- end }}
+            - name: INTERNAL_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nlweb.secrets.key.name" . }}
+                  key: internalTokenSecret
             - name: JSESSIONID_SECURE_FLAG
             {{- if eq ((include "nlweb.helpers.getScheme" .) | toString) "https://" }}
               value: "true"

--- a/templates/secrets-key.yaml
+++ b/templates/secrets-key.yaml
@@ -1,10 +1,16 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "nlweb.fullname" . }}-key-secret
+  name: {{ include "nlweb.secrets.key.name" . }}
   namespace: {{ .Release.Namespace }}  
   labels:
     {{- include "nlweb.labels" . | nindent 4 }}
 type: Opaque
+{{- $previous := lookup "v1" "Secret" .Release.Namespace (include "nlweb.secrets.key.name" .) }}
 data:
   nlwSecretKey: {{ .Values.neoload.configuration.secretKey | required "You need to specify a NLW secret key. (--set neoload.configuration.secretKey=mySecretKey)" | toString | b64enc | quote }}
+  {{- if $previous }}
+  internalTokenSecret: {{ $previous.data.internalTokenSecret }}
+  {{- else }}
+  internalTokenSecret: {{ randAlphaNum 128 | nospace | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
The value is initialized during installation and will not be modified when upgrading the chart.