### PR TITLE
Fix #32 - Use parentheses to protect optional values in the if statement

### DIFF
--- a/templates/secrets-key.yaml
+++ b/templates/secrets-key.yaml
@@ -9,7 +9,7 @@ type: Opaque
 {{- $previous := lookup "v1" "Secret" .Release.Namespace (include "nlweb.secrets.key.name" .) }}
 data:
   nlwSecretKey: {{ .Values.neoload.configuration.secretKey | required "You need to specify a NLW secret key. (--set neoload.configuration.secretKey=mySecretKey)" | toString | b64enc | quote }}
-  {{- if and ($previous) ($previous.data) ($previous.data.internalTokenSecret) }}
+  {{- if (($previous).data).internalTokenSecret }}
   internalTokenSecret: {{ $previous.data.internalTokenSecret }}
   {{- else }}
   internalTokenSecret: {{ randAlphaNum 128 | nospace | b64enc | quote }}


### PR DESCRIPTION
The feature is not described in the Helm documentation.
I've found it here: https://stackoverflow.com/a/68807258