### PR TITLE
Add domain to values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,8 @@ services:
     ingress:
       paths: ["/"]
 
+domain: .mycompany.com
+
 resources:
   backend:
     requests:


### PR DESCRIPTION
  With the newest helm chart, builds started failing because the domain value is required and was not included to the default yaml file after the update. I recommend having this value present so it will be easier from the user side to have the required values present and the user will be able to edit them appropriately. This was tested on k3s and rancher k8s setup with helm deployments.
  