### PR TITLE
Replaced deprecated "kubernetes.io/ingress.class" annotation

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{ $label }}: {{ $annotation | quote }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end -}}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/values-custom.yaml
+++ b/values-custom.yaml
@@ -39,9 +39,8 @@ domain: .mycompany.com
 ingress:
   enabled: true
   # Replace these annotations accordingly if you are not using the nginx ingress controller
+  className: nginx
   annotations:
-    # nginx
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
Supressed below install warning by replacing deprecated annotation with spec field
```
annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```