### PR TITLE
(improvement) - Allow easier extension of the Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,15 +318,15 @@ Parameter | Description | Default
 `services.webapp.host` | The hostname for the webapp/front deployment | 
 `services.webapp.type` | The service type for the webapp/front deployment | `ClusterIP`
 `services.webapp.port` | The service port for the webapp/front deployment | `80`
-`services.webapp.ingress.paths` | The path mapping for the webapp/front ingress | `[""]`
+`services.webapp.ingress.paths` | The path mapping for the webapp/front ingress. If value is null, ingress will not be created for this service. | `[""]`
 `services.api.host` | The hostname for the api deployment | 
 `services.api.type` | The service type for the api deployment | `ClusterIP`
 `services.api.port` | The service port for the api deployment | `80`
-`services.api.ingress.paths` | The path mapping for the api ingress | `[""]`
+`services.api.ingress.paths` | The path mapping for the api ingress. If value is null, ingress will not be created for this service. | `[""]`
 `services.files.host` | The hostname for the files deployment | 
 `services.files.type` | The service type for the files deployment | `ClusterIP`
 `services.files.port` | The service port for the files deployment | `80`
-`services.files.ingress.paths` | The path mapping for the files ingress | `[""]`
+`services.files.ingress.paths` | The path mapping for the files ingress. If value is null, ingress will not be created for this service. | `[""]`
  |  | 
 `ingress.enabled` | Enable ingresses | `true`
 `ingress.class` | Specifies which ingress controller class should listen to this ingress | `nginx`

--- a/README.md
+++ b/README.md
@@ -318,15 +318,15 @@ Parameter | Description | Default
 `services.webapp.host` | The hostname for the webapp/front deployment | 
 `services.webapp.type` | The service type for the webapp/front deployment | `ClusterIP`
 `services.webapp.port` | The service port for the webapp/front deployment | `80`
-`services.webapp.ingress.paths` | The path mapping for the webapp/front ingress. If value is null, ingress will not be created for this service. | `[""]`
+`services.webapp.ingress.paths` | The path mapping for the webapp/front ingress. If value is `null`, ingress will not be created for this service. | `[""]`
 `services.api.host` | The hostname for the api deployment | 
 `services.api.type` | The service type for the api deployment | `ClusterIP`
 `services.api.port` | The service port for the api deployment | `80`
-`services.api.ingress.paths` | The path mapping for the api ingress. If value is null, ingress will not be created for this service. | `[""]`
+`services.api.ingress.paths` | The path mapping for the api ingress. If value is `null`, ingress will not be created for this service. | `[""]`
 `services.files.host` | The hostname for the files deployment | 
 `services.files.type` | The service type for the files deployment | `ClusterIP`
 `services.files.port` | The service port for the files deployment | `80`
-`services.files.ingress.paths` | The path mapping for the files ingress. If value is null, ingress will not be created for this service. | `[""]`
+`services.files.ingress.paths` | The path mapping for the files ingress. If value is `null`, ingress will not be created for this service. | `[""]`
  |  | 
 `ingress.enabled` | Enable ingresses | `true`
 `ingress.class` | Specifies which ingress controller class should listen to this ingress | `nginx`
@@ -377,15 +377,6 @@ Parameter | Description | Default
 `tolerations` | Pod's tolerations | `[]`
 `replicaCount.frontend` | Number of frontend pods in your Deployment. [Learn more.](#high-availability) | 2
 `replicaCount.backend` | Number of backend pods in your Deployment. [Learn more.](#high-availability) | 2
- |  | 
-`hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
-`hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
-`hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
-`extra.containers.backend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the backend Deployment. |
-`extra.containers.frontend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the frontend Deployment. |
-`extra.volumes.frontend` | *Useful to attache volumes to a side car container.* Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the frontend Deployment. |
-`extra.volumes.backend` | *Useful to attache volumes to a side car container.* Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the backend Deployment. |
-
 
 We suggest you maintain your own *values-custom.yaml* and update it with your relevant parameters, but you can also specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -394,6 +385,32 @@ $ helm install my-release \
     --set ingress.tls=[] \
     neotys/nlweb
 ```
+
+#### Side-car containers (experimental)
+
+> [!NOTE]
+> **This feature is experimental.**
+> It allows to deploy side-car containers on the frontend and backend Deployments.
+
+> [!CAUTION]
+> When using `services.<name>.*` values the `<name>` must map the name of a port declared in containers under `extra.containers.backend` or `extra.containers.frontend`.
+
+
+Parameter | Description | Default
+----- | ----------- | -------
+`hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
+`hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
+`hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
+`extra.containers.backend` | Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the backend Deployment. |
+`extra.containers.frontend` | Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the frontend Deployment. |
+`extra.volumes.frontend` | Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the frontend Deployment. |
+`extra.volumes.backend` | Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the backend Deployment. |
+`services.<name>.component` | The Deployment to which this service attach it can be `frontend` or `backend` | 
+`services.<name>.host` | The hostname for the `<name>` service | 
+`services.<name>.type` | The type for the `<name>` service | `ClusterIP`
+`services.<name>.port` | The port for the `<name>` service | `80`
+`services.<name>.ingress.paths` | The path mapping for the service ingress. If value is `null`, ingress will not be created for this service. | `[""]`
+
 
 ## Custom environment variables
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ $ helm install my-release \
 > [!CAUTION]
 > When using `services.<name>.*` values the `<name>` must map the name of a port declared in containers under `extra.containers.backend` or `extra.containers.frontend`.
 
+For a detailed example on how to use this feature take a look at [this example](./doc/sidecar-example/README.md).
+
 
 Parameter | Description | Default
 ----- | ----------- | -------

--- a/README.md
+++ b/README.md
@@ -400,9 +400,9 @@ For a detailed example on how to use this feature take a look at [this example](
 
 Parameter | Description | Default
 ----- | ----------- | -------
-`hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
-`hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
-`hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
+`extra.hosts.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
+`extra.hosts.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
+`extra.hosts.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
 `extra.containers.backend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the backend Deployment. |
 `extra.containers.frontend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the frontend Deployment. |
 `extra.volumes.frontend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the frontend Deployment. |

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Parameter | Description | Default
 `extra.containers.frontend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the frontend Deployment. |
 `extra.volumes.frontend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the frontend Deployment. |
 `extra.volumes.backend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the backend Deployment. |
-`services.<name>.component` | The Deployment to which this service attach it can be `frontend` or `backend` | 
+`services.<name>.component` | [GPT] The Deployment to which this service is attached can be either `frontend` or `backend`. | 
 `services.<name>.host` | The hostname for the `<name>` service | 
 `services.<name>.type` | The type for the `<name>` service | `ClusterIP`
 `services.<name>.port` | The port for the `<name>` service | `80`

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ Parameter | Description | Default
 `hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
 `extra.containers.backend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the backend Deployment. |
 `extra.containers.frontend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the frontend Deployment. |
+`extra.volumes.frontend` | *Useful to attache volumes to a side car container.* Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the frontend Deployment. |
+`extra.volumes.backend` | *Useful to attache volumes to a side car container.* Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the backend Deployment. |
+
 
 We suggest you maintain your own *values-custom.yaml* and update it with your relevant parameters, but you can also specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/README.md
+++ b/README.md
@@ -403,10 +403,10 @@ Parameter | Description | Default
 `hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
 `hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
 `hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
-`extra.containers.backend` | Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the backend Deployment. |
-`extra.containers.frontend` | Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the frontend Deployment. |
-`extra.volumes.frontend` | Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the frontend Deployment. |
-`extra.volumes.backend` | Allows to specify a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). They will be to the PodSpec of the backend Deployment. |
+`extra.containers.backend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the backend Deployment. |
+`extra.containers.frontend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the frontend Deployment. |
+`extra.volumes.frontend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the frontend Deployment. |
+`extra.volumes.backend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the backend Deployment. |
 `services.<name>.component` | The Deployment to which this service attach it can be `frontend` or `backend` | 
 `services.<name>.host` | The hostname for the `<name>` service | 
 `services.<name>.type` | The type for the `<name>` service | `ClusterIP`

--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Parameter | Description | Default
 `hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
 `hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
 `hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
+`extra.containers.backend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the backend Deployment. |
+`extra.containers.frontend` | *Useful to run side car containers.* Allows to specify a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). They will be appended to the list of Containers of the frontend Deployment. |
 
 We suggest you maintain your own *values-custom.yaml* and update it with your relevant parameters, but you can also specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ Parameter | Description | Default
 `tolerations` | Pod's tolerations | `[]`
 `replicaCount.frontend` | Number of frontend pods in your Deployment. [Learn more.](#high-availability) | 2
 `replicaCount.backend` | Number of backend pods in your Deployment. [Learn more.](#high-availability) | 2
+ |  | 
+`hostOverrides.webapp` | Overrides the app configuration if the hostname used to access NeoLoad Web Frontend is different than the value of `services.webapp.host`|
+`hostOverrides.api` | Overrides the app configuration if the hostname used to access NeoLoad Web API is different than the value of `services.api.host`|
+`hostOverrides.files` | Overrides the app configuration if the hostname used to access NeoLoad Web Files API is different than the value of `services.files.host`|
 
 We suggest you maintain your own *values-custom.yaml* and update it with your relevant parameters, but you can also specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -2,11 +2,13 @@
 
 > [!WARNING] 
 > **This feature is experimental.**
+> 
 > It allows to deploy side-car containers on the frontend and backend Deployments.
 > As it is experimental, this document may not be updated on each releases.
 > It has been added starting with version 2.x.y //TODO define version.
 >
-> The following content is provided as a basis. It needs to be adapted by yourself to your specific use case.
+> The following content is provided as a basis. 
+> It needs to be adapted by yourself to your specific use case.
 
 ## Goals
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -84,10 +84,11 @@ services:
 Add the following section in the values file.
 
 ```diff
-+ hostOverrides:
-+   webapp: neoload-web.mycompany.com
-+   api: neoload-web-api.mycompany.com
-+   files: neoload-web-files.mycompany.com
++ extra:
++   hosts:
++     webapp: neoload-web.mycompany.com
++     api: neoload-web-api.mycompany.com
++     files: neoload-web-files.mycompany.com
 ```
 
 #### Defining side-car containers

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -4,7 +4,9 @@
 >
 > It allows to deploy side-car containers on the frontend and backend Deployments.
 > As it is experimental, this document may not be updated on each releases.
-> It has been added starting with version 2.x.y //TODO define version.
+> It has been added starting with versions:
+> - 2.15.3+ for NeoLoad Web 2024.1.x
+> - 2.17.0+ for NeoLoad Web 2024.3.x and later
 >
 > The following content is provided as an example and must be adapted to your specific use case.
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -1,6 +1,6 @@
 # How to inject side-cars?
 
-> [!WARNING] > **This feature is experimental.**
+> [!WARNING] **This feature is experimental.**
 > It allows to deploy side-car containers on the frontend and backend Deployments.
 > As it is experimental, this document may not be updated on each releases.
 > It has been added starting with version 2.x.y //TODO define version.

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -23,7 +23,7 @@ It uses the values defined in the section [Side-car containers (experimental)](.
 
 ##### Prevent creation of Ingress for default services
 
-By defining `values.(webapp|api|files).ingress` to `null`, this will prevent the creation of Ingress for those services.
+Set `values.(webapp|api|files).ingress` to `null` to prevent the creation of Ingress for those services. `values.(webapp|api|files).host` can be removed as they will not be used in that scenario.
 
 ```diff
 ### Services host configuration

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -8,7 +8,8 @@
 > It has been added starting with version 2.x.y //TODO define version.
 >
 > The following content is provided as a basis. 
-> It needs to be adapted by yourself to your specific use case.
+>
+> It must be adapted by yourself to your specific use case.
 
 ## Goals
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -7,9 +7,7 @@
 > As it is experimental, this document may not be updated on each releases.
 > It has been added starting with version 2.x.y //TODO define version.
 >
-> The following content is provided as a basis. 
->
-> It must be adapted by yourself to your specific use case.
+> The following content is provided as an example and must be adapted to your specific use case.
 
 ## Goals
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -39,7 +39,7 @@ services:
 +    ingress: null
 ```
 
-##### Adding new services for side-cars
+##### Adding custom services for side-cars
 
 Now let's define services for our side-cars. This will allow to create Services & Ingresses.
 

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -1,6 +1,7 @@
 # How to inject side-cars?
 
-> [!WARNING] **This feature is experimental.**
+> [!WARNING] 
+> **This feature is experimental.**
 > It allows to deploy side-car containers on the frontend and backend Deployments.
 > As it is experimental, this document may not be updated on each releases.
 > It has been added starting with version 2.x.y //TODO define version.

--- a/doc/sidecar-example/README.md
+++ b/doc/sidecar-example/README.md
@@ -1,0 +1,127 @@
+# How to inject side-cars?
+
+> [!WARNING] > **This feature is experimental.**
+> It allows to deploy side-car containers on the frontend and backend Deployments.
+> As it is experimental, this document may not be updated on each releases.
+> It has been added starting with version 2.x.y //TODO define version.
+>
+> The following content is provided as a basis. It needs to be adapted by yourself to your specific use case.
+
+## Goals
+
+This document demonstrates how to setup a simple (no SSL) nginx proxy as sidecar on the frontend and backend Pods.
+It uses the values defined in the section [Side-car containers (experimental)](../../README.md#side-car-containers-experimental).
+
+### Updating values file
+
+> [!NOTE]
+> The following diffs are based on [values-custom.yaml file](../../values-custom.yaml).
+
+#### Update `services` values
+
+##### Prevent creation of Ingress for default services
+
+By defining `values.(webapp|api|files).ingress` to `null`, this will prevent the creation of Ingress for those services.
+
+```diff
+### Services host configuration
+services:
+  webapp:
+-    host: neoload-web.mycompany.com
++    ingress: null
+  api:
+-    host: neoload-web-api.mycompany.com
++    ingress: null
+  files:
+-    host: neoload-web-files.mycompany.com
++    ingress: null
+```
+
+##### Adding new services for side-cars
+
+Now let's define services for our side-cars. This will allow to create Services & Ingresses.
+
+> [!CAUTION]
+> Label of your services **must** match the name of ports from your side-car containers.
+> In the following example, it means that `webapp-proxy`, `api-proxy` and `files-proxy` are names of your side-car containers.
+
+```diff
+### Services host configuration
+services:
+  webapp:
+    ingress: null
+  api:
+    ingress: null
+  files:
+    ingress: null
++  webapp-proxy:
++    component: frontend
++    host: neoload-web.mycompany.com
++    type: ClusterIP
++    port: 80
++    ingress:
++      paths: ["/"]
++  api-proxy:
++    component: backend
++    host: neoload-web-api.mycompany.com
++    type: ClusterIP
++    port: 80
++    ingress:
++      paths: ["/"]
++  files-proxy:
++    component: backend
++    host: neoload-web-files.mycompany.com
++    type: ClusterIP
++    port: 80
++    ingress:
++      paths: ["/"]
+```
+
+##### Overriding hosts configuration
+
+Add the following section in the values file.
+
+```diff
++ hostOverrides:
++   webapp: neoload-web.mycompany.com
++   api: neoload-web-api.mycompany.com
++   files: neoload-web-files.mycompany.com
+```
+
+#### Defining side-car containers
+
+Use the new values `extra.containers.backend` and `extra.containers.frontend` provide definition of your side-cars.
+These values expect an array of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core).
+
+See [`values-custom-side-car.yaml`](./values-custom-side-car.yaml) for a full example.
+
+> [!CAUTION]
+> As seen in a [previous section](#adding-new-services-for-side-cars) the port names in your containers must match the name of services defined previously.
+
+#### Defining additional volumes
+
+You may notice that the containers in the previous example are referencing volumes.
+You can define additional volumes through the `extra.volumes.backend` and `extra.volumes.frontend` values.
+
+See [`values-custom-side-car.yaml`](./values-custom-side-car.yaml) for a full example.
+
+> [!NOTE]
+> Volumes `proxy-frontend-conf-volume` and `proxy-backend-conf-volume` are referencing a ConfigMap. See the [nginx configuration](#nginx-configuration) section for more details.
+
+### nginx configuration
+
+> [!NOTE]
+> This section doesn't relate directly to the chart configuration. This is provided as a basis that you must adapt to your specific case!
+
+Configuring a reverse proxy for NeoLoad Web requires specific configuration. Here are simple (without SSL) nginx configuration examples for frontend and backend.
+
+- [frontend configuration](./nginx-conf-frontend.conf)
+- [backend configuration](./nginx-conf-backend.conf)
+
+#### Creating ConfigMap
+
+In the provided example the ConfigMap has been created with the following command.
+
+```shell
+kubectl create configmap nginx-conf --from-file=nginx-conf-frontend.conf --from-file=nginx-conf-backend.conf
+```

--- a/doc/sidecar-example/nginx-conf-backend.conf
+++ b/doc/sidecar-example/nginx-conf-backend.conf
@@ -1,0 +1,62 @@
+error_log stderr error;
+worker_processes  1;
+events {
+  worker_connections 1024;
+}
+
+http {
+
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+  }
+
+  server {
+    listen 1443;
+    server_name neoload-web-api.mycompany.com;
+
+    error_page 497  https://$host:$server_port$request_uri;
+
+    location ~ .* {
+      gzip on;
+
+      client_max_body_size          50M;
+      proxy_set_header              Connection "";
+      proxy_set_header              Host $http_host;
+      proxy_set_header              X-Real-IP $remote_addr;
+      proxy_set_header              X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-Proto $proxy_x_forwarded_proto;
+      proxy_set_header              X-Frame-Options SAMEORIGIN;
+      proxy_buffers                 256 16k;
+      proxy_buffer_size             16k;
+      proxy_read_timeout            600s;
+      proxy_ignore_client_abort     on;
+      proxy_pass                    http://localhost:1081;
+      proxy_redirect                off;
+    }
+  }
+  server {
+    listen 1444;
+    server_name neoload-web-files.mycompany.com;
+
+    error_page 497  https://$host:$server_port$request_uri;
+
+    location ~ .* {
+      gzip on;
+
+      client_max_body_size        250M;
+      proxy_set_header            Connection "";
+      proxy_set_header            Host $http_host;
+      proxy_set_header            X-Real-IP $remote_addr;
+      proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header            X-Forwarded-Proto $proxy_x_forwarded_proto;
+      proxy_set_header            X-Frame-Options SAMEORIGIN;
+      proxy_buffers               256 16k;
+      proxy_buffer_size           16k;
+      proxy_read_timeout          600s;
+      proxy_ignore_client_abort   on;
+      proxy_pass                  http://localhost:1082;
+      proxy_redirect              off;
+    }
+  }
+}

--- a/doc/sidecar-example/nginx-conf-backend.conf
+++ b/doc/sidecar-example/nginx-conf-backend.conf
@@ -15,8 +15,6 @@ http {
     listen 1443;
     server_name neoload-web-api.mycompany.com;
 
-    error_page 497  https://$host:$server_port$request_uri;
-
     location ~ .* {
       gzip on;
 
@@ -38,8 +36,6 @@ http {
   server {
     listen 1444;
     server_name neoload-web-files.mycompany.com;
-
-    error_page 497  https://$host:$server_port$request_uri;
 
     location ~ .* {
       gzip on;

--- a/doc/sidecar-example/nginx-conf-frontend.conf
+++ b/doc/sidecar-example/nginx-conf-frontend.conf
@@ -23,8 +23,6 @@ http {
     listen      1443;
     server_name neoload-web.mycompany.com;
 
-    error_page 497  https://$host:$server_port$request_uri;
-
     location ~ /PUSH {
       proxy_pass 				  http://localhost:9090;
       proxy_http_version  1.1;

--- a/doc/sidecar-example/nginx-conf-frontend.conf
+++ b/doc/sidecar-example/nginx-conf-frontend.conf
@@ -1,0 +1,57 @@
+error_log stderr error;
+worker_processes  1;
+events {
+  worker_connections 1024;
+}
+
+http {
+  map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+  }
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  upstream websocket {
+    server localhost:9090;
+  }
+
+  server {
+    listen      1443;
+    server_name neoload-web.mycompany.com;
+
+    error_page 497  https://$host:$server_port$request_uri;
+
+    location ~ /PUSH {
+      proxy_pass 				  http://localhost:9090;
+      proxy_http_version  1.1;
+      proxy_set_header    Host $http_host;
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "upgrade";
+      proxy_set_header 		X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header 		X-Forwarded-Proto $proxy_x_forwarded_proto;
+      proxy_set_header 		X-Frame-Options SAMEORIGIN;
+    }
+
+    location ~ .* {
+      gzip on;
+
+      client_max_body_size  50M;
+      proxy_set_header      Connection "";
+      proxy_set_header      Host $http_host;
+      proxy_set_header      X-Real-IP $remote_addr;
+      proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header      X-Forwarded-Proto $proxy_x_forwarded_proto;
+      proxy_set_header      X-Frame-Options SAMEORIGIN;
+      proxy_buffers 256     16k;
+      proxy_buffer_size     16k;
+      proxy_read_timeout    600s;
+      proxy_pass            http://localhost:9090;
+        proxy_redirect off;
+    }
+  }
+}

--- a/doc/sidecar-example/values-custom-side-car.yaml
+++ b/doc/sidecar-example/values-custom-side-car.yaml
@@ -1,0 +1,166 @@
+### ReplicaSet configuration
+replicaCount:
+  frontend: 2
+  backend: 2
+
+### NLWeb configuration
+neoload:
+  configuration:
+    # The secret key must be at least 8 characters long
+    secretKey: YOUR_CUSTOM_SECRET_KEY
+    backend:
+      mongo:
+        host: YOUR_MONGODB_HOST_URL
+        port: 27017
+      # Enable licensing features (VUHs) by setting this token, or leave it empty
+      licensingPlatformToken:
+securityContext:
+  runAsUser: 10000
+
+### MongoDB user configuration
+mongodb:
+  usePassword: true
+  mongodbUsername: YOUR_MONGODB_USER
+  mongodbPassword: YOUR_MONGODB_PASSWORD
+
+### Services host configuration
+services:
+  webapp:
+    ingress: null
+  api:
+    ingress: null
+  files:
+    ingress: null    
+  webapp-proxy:
+    component: frontend
+    host: neoload-web.mycompany.com
+    type: ClusterIP
+    port: 80
+    ingress:
+      paths: ["/"]
+  api-proxy:
+    component: backend
+    host: neoload-web-api.mycompany.com
+    type: ClusterIP
+    port: 80
+    ingress:
+      paths: ["/"]
+  files-proxy:
+    component: backend
+    host: neoload-web-files.mycompany.com
+    type: ClusterIP
+    port: 80
+    ingress:
+      paths: ["/"]
+
+domain: .mycompany.com
+
+### Ingress configuration
+### Choose your preferred ingress controller configuration
+ingress:
+  enabled: true
+  # Replace these annotations accordingly if you are not using the nginx ingress controller
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_ignore_client_abort "on";  
+    nginx.ingress.kubernetes.io/proxy-body-size: 0
+    # Enable sticky sessions for HA
+    # More parameters here : https://kubernetes.github.io/ingress-nginx/examples/affinity/cookie/
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/affinity-mode: persistent
+    nginx.ingress.kubernetes.io/session-cookie-max-age: 3600
+    nginx.ingress.kubernetes.io/session-cookie-change-on-failure: true
+
+  ### TLS configuration
+  ### Uncomment if you want to secure your app with https
+#  tls:
+#    - secretName: tls-secret
+#      secretCertificate: |-
+#        -----BEGIN CERTIFICATE-----
+#        YOUR_CERTIFICATE
+#        -----END CERTIFICATE-----
+#      secretKey: |-
+#        -----BEGIN PRIVATE KEY-----
+#        YOUR_PRIVATE_KEY
+#        -----END PRIVATE KEY-----
+
+hostOverrides:
+  webapp: neoload-web.mycompany.com
+  api: neoload-web-api.mycompany.com
+  files: neoload-web-files.mycompany.com
+
+extra:
+  containers:
+    backend:
+    - name: nginx-proxy
+      image: nginx:1.27.1-alpine
+      imagePullPolicy: Always
+      command: [ "/bin/sh", "-c", "nginx -g 'daemon off;'" ]
+      ports:
+      - name: api-proxy
+        containerPort: 1443
+      - name: files-proxy
+        containerPort: 1444
+      resources: 
+        requests:
+          cpu: 100m
+          memory: 10Mi
+        limits:
+          memory: 20Mi
+      volumeMounts:
+      - name: proxy-backend-conf-volume
+        mountPath: /etc/nginx/nginx.conf
+        subPath: nginx.conf
+      - name: proxy-backend-cache-volume
+        mountPath: /var/cache/nginx
+      - name: proxy-backend-run-volume
+        mountPath: /var/run
+    frontend:
+    - name: nginx-proxy
+      image: nginx:1.27.1-alpine
+      imagePullPolicy: Always
+      command: [ "/bin/sh", "-c", "nginx -g 'daemon off;'" ]
+      ports:
+      - name: webapp-proxy
+        containerPort: 1443
+      resources: 
+        requests:
+          cpu: 100m
+          memory: 10Mi
+        limits:
+          memory: 20Mi
+      volumeMounts:
+      - name: proxy-frontend-conf-volume
+        mountPath: /etc/nginx/nginx.conf
+        subPath: nginx.conf
+      - name: proxy-frontend-cache-volume
+        mountPath: /var/cache/nginx
+      - name: proxy-frontend-run-volume
+        mountPath: /var/run
+  volumes:
+    frontend:
+    - name: proxy-frontend-conf-volume
+      configMap:
+        name: nginx-conf
+        items:
+          - key: nginx-conf-frontend.conf
+            path: nginx.conf
+    - name: proxy-frontend-cache-volume
+      emptyDir: {}
+    - name: proxy-frontend-run-volume
+      emptyDir: {}
+    backend:
+    - name: proxy-backend-conf-volume
+      configMap:
+        name: nginx-conf
+        items:
+          - key: nginx-conf-backend.conf
+            path: nginx.conf
+    - name: proxy-backend-cache-volume
+      emptyDir: {}
+    - name: proxy-backend-run-volume
+      emptyDir: {}

--- a/doc/sidecar-example/values-custom-side-car.yaml
+++ b/doc/sidecar-example/values-custom-side-car.yaml
@@ -88,12 +88,11 @@ ingress:
 #        YOUR_PRIVATE_KEY
 #        -----END PRIVATE KEY-----
 
-hostOverrides:
-  webapp: neoload-web.mycompany.com
-  api: neoload-web-api.mycompany.com
-  files: neoload-web-files.mycompany.com
-
 extra:
+  hosts:
+    webapp: neoload-web.mycompany.com
+    api: neoload-web-api.mycompany.com
+    files: neoload-web-files.mycompany.com
   containers:
     backend:
     - name: nginx-proxy

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled }}
 1. Access the application with the following URL:
 {{- range $label, $service := .Values.services }}
-  {{ include "nlweb.helpers.getScheme" $ }}{{ $service.host }}
+  {{- if $service.ingress }}
+    {{ include "nlweb.helpers.getScheme" $ }}{{ $service.host }}
+  {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.services.webapp.type }}
 1. Get the application URL by running these commands:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -177,3 +177,37 @@ High Availability (HA) Mode
 {{- define "nlweb.service-hazelcast-name" -}}
     {{ include "nlweb.fullname" . }}-svc-hazelcast-{{ include "nlweb.ha.mode" . | lower }}
 {{- end -}}
+
+
+{{/*
+Define webapp host, default to .Values.services.webapp.host but can be overrided by .Values.hostOverrides.webapp
+*/}}
+{{- define "nlweb.webapp.host" -}}
+    {{- if ((.Values.hostOverrides).webapp) -}}
+        {{- .Values.hostOverrides.webapp -}}
+    {{- else -}}
+        {{- .Values.services.webapp.host -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Define api host, default to .Values.services.api.host but can be overrided by .Values.hostOverrides.api
+*/}}
+{{- define "nlweb.api.host" -}}
+    {{- if ((.Values.hostOverrides).api) -}}
+        {{- .Values.hostOverrides.api -}}
+    {{- else -}}
+        {{- .Values.services.api.host -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Define files host, default to .Values.services.files.host but can be overrided by .Values.hostOverrides.files
+*/}}
+{{- define "nlweb.files.host" -}}
+    {{- if ((.Values.hostOverrides).files) -}}
+        {{- .Values.hostOverrides.files -}}
+    {{- else -}}
+        {{- .Values.services.files.host -}}
+    {{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -180,33 +180,33 @@ High Availability (HA) Mode
 
 
 {{/*
-Define webapp host, default to .Values.services.webapp.host but can be overrided by .Values.hostOverrides.webapp
+Define webapp host, default to .Values.services.webapp.host but can be overrided by .Values.extra.hosts.webapp
 */}}
 {{- define "nlweb.webapp.host" -}}
-    {{- if ((.Values.hostOverrides).webapp) -}}
-        {{- .Values.hostOverrides.webapp -}}
+    {{- if ((.Values.extra.hosts).webapp) -}}
+        {{- .Values.extra.hosts.webapp -}}
     {{- else -}}
         {{- .Values.services.webapp.host -}}
     {{- end -}}
 {{- end -}}
 
 {{/*
-Define api host, default to .Values.services.api.host but can be overrided by .Values.hostOverrides.api
+Define api host, default to .Values.services.api.host but can be overrided by .Values.extra.hosts.api
 */}}
 {{- define "nlweb.api.host" -}}
-    {{- if ((.Values.hostOverrides).api) -}}
-        {{- .Values.hostOverrides.api -}}
+    {{- if ((.Values.extra.hosts).api) -}}
+        {{- .Values.extra.hosts.api -}}
     {{- else -}}
         {{- .Values.services.api.host -}}
     {{- end -}}
 {{- end -}}
 
 {{/*
-Define files host, default to .Values.services.files.host but can be overrided by .Values.hostOverrides.files
+Define files host, default to .Values.services.files.host but can be overrided by .Values.extra.hosts.files
 */}}
 {{- define "nlweb.files.host" -}}
-    {{- if ((.Values.hostOverrides).files) -}}
-        {{- .Values.hostOverrides.files -}}
+    {{- if ((.Values.extra.hosts).files) -}}
+        {{- .Values.extra.hosts.files -}}
     {{- else -}}
         {{- .Values.services.files.host -}}
     {{- end -}}

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -154,6 +154,9 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources.backend | nindent 12 }}
+        {{- if ((.Values.extra).containers).backend }}
+        {{- toYaml .Values.extra.containers.backend | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -169,3 +169,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ((.Values.extra).volumes).backend }}
+      volumes:
+        {{- toYaml .Values.extra.volumes.backend | nindent 8 }}
+    {{- end }}

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -74,11 +74,11 @@ spec:
             - name: MONGODB_MAX_POOLSIZE
               value: {{ .Values.neoload.configuration.backend.mongo.poolSize | quote }}
             - name: NEOLOAD_WEB_PUBLIC_URL
-              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (.Values.services.webapp.host) | required "NeoLoad Web Public URL (.Values.services.webapp.host) value is required." | quote }}
+              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (include "nlweb.webapp.host" .) | required "NeoLoad Web Public URL (.Values.services.webapp.host) value is required." | quote }}
             - name: NEOLOAD_WEB_API_PUBLIC_URL
-              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (.Values.services.api.host) | required "NeoLoad Web API URL (.Values.services.api.host) value is required." | quote }}
+              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (include "nlweb.api.host" .) | required "NeoLoad Web API URL (.Values.services.api.host) value is required." | quote }}
             - name: FILE_STORAGE_ROUTER_BASE_URL
-              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (.Values.services.files.host) | required "NeoLoad Web Files API URL (.Values.services.files.host) value is required." | quote }}
+              value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (include "nlweb.files.host" .) | required "NeoLoad Web Files API URL (.Values.services.files.host) value is required." | quote }}
             - name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
               value: "http://{{ include "nlweb.fullname" . }}-svc-files.{{ .Release.Namespace }}.svc.cluster.local"              
             - name: FILE_PROJECT_MAX_SIZE_IN_BYTES

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -137,3 +137,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if ((.Values.extra).volumes).frontend }}
+      volumes:
+        {{- toYaml .Values.extra.volumes.frontend | nindent 8 }}
+    {{- end }}

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -122,6 +122,9 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources.frontend | nindent 12 }}
+        {{- if ((.Values.extra).containers).frontend }}
+        {{- toYaml .Values.extra.containers.frontend | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -39,23 +39,14 @@ spec:
 {{- end }}
   rules:
     {{- range $label, $service := .Values.services }}
+    {{- if $service.ingress }}
     {{- $serviceName := printf "%s-%s-%s" (include "nlweb.fullname" $) "svc" $label }}
     - host: {{ $service.host | quote }}
       http:
       {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
         paths:
-        {{- if $service.ingress }}
         {{- range $service.ingress.paths }}
         - path: {{ . }}
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ $serviceName }}
-              port:
-                number: {{ $service.port }}
-        {{- end }}
-        {{- else -}}
-        - path: "/"
           pathType: Prefix
           backend:
             service:
@@ -65,19 +56,13 @@ spec:
         {{- end }}
       {{- else }}
         paths:
-        {{- if $service.ingress }}
         {{- range $service.ingress.paths }}
         - path: {{ . }}
           backend:
             serviceName: {{ $serviceName }}
             servicePort: {{ $service.port }}
         {{- end }}
-        {{- else -}}
-        - path: "/"
-          backend:
-            serviceName: {{ $serviceName }}
-            servicePort: {{ $service.port }}
-        {{- end }}
+      {{- end }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -22,6 +22,14 @@ spec:
     {{- include "nlweb.frontend.selectorLabels" $ | nindent 4 }}
     {{- else if or (eq $label "files") (eq $label "api") }}
     {{- include "nlweb.backend.selectorLabels" $ | nindent 4 }}
+    {{- else }}
+      {{- if eq $service.component "backend" }}
+      {{- include "nlweb.backend.selectorLabels" $ | nindent 4 }}
+      {{- else if eq $service.component "frontend" }}
+      {{- include "nlweb.frontend.selectorLabels" $ | nindent 4 }}
+      {{- else }}
+      {{ required "Custom services must have a 'component' property with value equals to 'frontend' or 'backend'" $service.component }}
+      {{- end}}
     {{- end }}
 
 ---

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -28,7 +28,7 @@ spec:
       {{- else if eq $service.component "frontend" }}
       {{- include "nlweb.frontend.selectorLabels" $ | nindent 4 }}
       {{- else }}
-      {{ required "Custom services must have a 'component' property with value equals to 'frontend' or 'backend'" $service.component }}
+      {{ required "Custom services must have a 'component' property with value equal to 'frontend' or 'backend'" $service.component }}
       {{- end}}
     {{- end }}
 


### PR DESCRIPTION
- Allows to prevent ingress creation for specific services by settings `service.<name>.ingress` to `null`
- Allows to override webapp, api and files hostnames by defining `hostOverrides` values.
- Allows to provide sidecar containers definition to the chart for frontend and backend Deployments.
- Allows to define volumes to frontend and backend Pods.
- Adds an example about how to configure a nginx reverse proxy for NeoLoad Web.