### PR TITLE
Adjust the livenessProbe value through Helm / custom-values.yaml #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,13 @@ Parameter | Description | Default
 `neoload.configuration.backend.misc.files.maxUploadSizeInBytes` | Max file upload size in bytes | `250000000`
 `neoload.configuration.backend.misc.files.maxUploadPerWeek` | Max file upload count per week | `250`
 `neoload.configuration.backend.licensingPlatformToken` | Token for enabling licensing features (such as VUHs) | 
+`neoload.configuration.backend.livenessProbe.initDelaySeconds` | Backend Pods liveness probe initial delay in seconds | 60
+`neoload.configuration.backend.readinessProbe.initDelaySeconds` | Backend Pods readiness probe initial delay in seconds | 60
 `neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `neoload.configuration.frontend.java.xmx` | Java JVM Max heap size for the frontend | `1200m`
+`neoload.configuration.frontend.livenessProbe.initDelaySeconds` | Frontend Pods liveness probe initial delay in seconds | 60
+`neoload.configuration.frontend.readinessProbe.initDelaySeconds` | Frontend Pods readiness probe initial delay in seconds | 20
 `neoload.configuration.frontend.others` | Custom frontend environment variables. [Learn more.](#custom-environment-variables) |
 | | 
 `neoload.configuration.proxy.https` | Connection string for your https proxy. [Learn more.](#proxy)

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -144,13 +144,13 @@ spec:
             httpGet:
               path: /status
               port: api
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ .Values.neoload.configuration.backend.livenessProbe.initDelaySeconds }}
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /status
               port: api
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ .Values.neoload.configuration.backend.readinessProbe.initDelaySeconds }}
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources.backend | nindent 12 }}

--- a/templates/deployment-front.yaml
+++ b/templates/deployment-front.yaml
@@ -112,13 +112,13 @@ spec:
             httpGet:
               path: /
               port: webapp
-            initialDelaySeconds: 60
+            initialDelaySeconds: {{ .Values.neoload.configuration.frontend.livenessProbe.initDelaySeconds }}
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: webapp
-            initialDelaySeconds: 20
+            initialDelaySeconds: {{ .Values.neoload.configuration.frontend.readinessProbe.initDelaySeconds }}
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources.frontend | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -94,9 +94,17 @@ neoload:
           maxUploadSizeInBytes: "250000000"
           maxUploadPerWeek: "250"
       licensingPlatformToken: 
+      livenessProbe:
+        initDelaySeconds: 60
+      readinessProbe:
+        initDelaySeconds: 60
     frontend:
       java:
         xmx: 1200m
+      livenessProbe:
+        initDelaySeconds: 60
+      readinessProbe:
+        initDelaySeconds: 20
     ha:
       mode: "API"
     secretKey: 


### PR DESCRIPTION
Fixing #65 by allowing to configure liveness and readiness probes for frontend and backend Pods through values.