### PR TITLE
LOAD-34491 - Add a value allowing to define extra volume mounts on the NLW backend container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ Parameter | Description | Default
 `replicaCount.frontend` | Number of frontend pods in your Deployment. [Learn more.](#high-availability) | 2
 `replicaCount.backend` | Number of backend pods in your Deployment. [Learn more.](#high-availability) | 2
 `loggerConfiguration` | Logger configuration. [Learn more.](./doc/logging-configuration.md) | [Default logger configuration as defined here](./values.yaml)
+`extra.volumes.backend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the backend Deployment. |
+`extra.volumeMounts.backend` | Add custom volume mounts to the NeoLoad Web backend Container.  | 
 
 We suggest you maintain your own *values-custom.yaml* and update it with your relevant parameters, but you can also specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -411,8 +413,7 @@ Parameter | Description | Default
 `extra.containers.backend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the backend Deployment. |
 `extra.containers.frontend` | Allows specifying a list of valid [Containers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#container-v1-core). These will be added to the list of Containers of the frontend Deployment. |
 `extra.volumes.frontend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the frontend Deployment. |
-`extra.volumes.backend` | Allows specifying a list of valid [Volumes](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volume-v1-core). These will be added to the PodSpec of the backend Deployment. |
-`services.<name>.component` | [GPT] The Deployment to which this service is attached can be either `frontend` or `backend`. | 
+`services.<name>.component` | The Deployment to which this service is attached can be either `frontend` or `backend`. | 
 `services.<name>.host` | The hostname for the `<name>` service | 
 `services.<name>.type` | The type for the `<name>` service | `ClusterIP`
 `services.<name>.port` | The port for the `<name>` service | `80`

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -157,6 +157,9 @@ spec:
           volumeMounts:
             - name: {{ .Release.Name }}-logger-config
               mountPath: /server/conf
+        {{- if ((.Values.extra).volumeMounts).backend }}
+            {{- toYaml .Values.extra.volumeMounts.backend | nindent 12 }}
+        {{- end }}
         {{- if ((.Values.extra).containers).backend }}
         {{- toYaml .Values.extra.containers.backend | nindent 8 }}
         {{- end }}

--- a/values-custom.yaml
+++ b/values-custom.yaml
@@ -54,6 +54,7 @@ ingress:
     nginx.ingress.kubernetes.io/session-cookie-max-age: 3600
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: true
 
+
   ### TLS configuration
   ### Uncomment if you want to secure your app with https
 #  tls:


### PR DESCRIPTION
This new capacity will ease the deployment when MongoDB is using TLS with self-signed certificates.