### PR TITLE
fix(ingress): preserve YAML newlines in TLS hosts block (SWAT-9562)

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -40,12 +40,12 @@ spec:
   {{- range .Values.ingress.tls }}
     - secretName: {{ .secretName }}
       hosts:
-      {{- if .hosts -}}
-      {{- range .hosts }}
+      {{ if .hosts }}
+      {{ range .hosts }}
         - {{ . | quote }}
-      {{- end }}
-      {{- else -}}
-      {{- range $label, $service := $.Values.services }}
+      {{ end }}
+      {{ else }}
+      {{ range $label, $service := $.Values.services }}
         {{- /* Compute host with helpers for known services, keep value for customs */ -}}
         {{- $hostCtx := dict "val" $service.host -}}
         {{- if eq $label "webapp" -}}
@@ -58,8 +58,8 @@ spec:
           {{- $_ := set $hostCtx "val" (include "nlweb.files.host" $) -}}
         {{- end -}}
         - {{ (get $hostCtx "val") | required (printf "The %s service host is required. (--set services.%s.host=YOUR_HOST)" $label $label) | quote }}
+      {{ end }}
       {{- end }}
-      {{- end -}}
   {{- end }}
 {{- end }}
   rules:

--- a/tests/ingress-annotations_test.yaml
+++ b/tests/ingress-annotations_test.yaml
@@ -80,6 +80,30 @@ tests:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
           value: "500m"
 
+  # SWAT-9562: With only secretName (no tls[].hosts), hosts are derived from services.
+  # Bug: if/range/end used with {{- -}} so newlines after "hosts:" and between list items
+  # were stripped, yielding invalid YAML (e.g. hosts:- "a"- "b") and helm install failed.
+  - it: should render valid Ingress when ingress.tls has only secretName (auto hosts, SWAT-9562)
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.api-v4.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: true
+      ingress.tls[0].secretName: my-tls
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-tls
+      - lengthEqual:
+          path: spec.tls[0].hosts
+          count: 4
+
   - it: should allow haproxy rewrite-target when migration.skipBreakingChangesChecks is true
     release:
       namespace: default

--- a/tests/ingress-annotations_test.yaml
+++ b/tests/ingress-annotations_test.yaml
@@ -80,9 +80,6 @@ tests:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
           value: "500m"
 
-  # SWAT-9562: With only secretName (no tls[].hosts), hosts are derived from services.
-  # Bug: if/range/end used with {{- -}} so newlines after "hosts:" and between list items
-  # were stripped, yielding invalid YAML (e.g. hosts:- "a"- "b") and helm install failed.
   - it: should render valid Ingress when ingress.tls has only secretName (auto hosts, SWAT-9562)
     release:
       namespace: default


### PR DESCRIPTION
## Summary
Fixes invalid YAML in the `Ingress` manifest when `ingress.tls` is enabled with only `secretName` (hosts derived from `services.*`). Whitespace control on `if` / `range` / `end` stripped newlines after `hosts:` and between list items, which broke `helm install` (e.g. on OpenShift) with a parse error.

## Changes
- **templates/ingress.yaml:** use non-trimming `{{ if }}` / `{{ range }}` / `{{ end }}` for the TLS `hosts` auto-population path.
- **tests/ingress-annotations_test.yaml:** add a helm-unittest regression for TLS with `secretName` only (SWAT-9562).
