### PR TITLE
test+docs(ingress): TLS coverage and multi-tls README (SWAT-9562 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,68 @@ To enable TLS and access NeoLoad Web via https, the parameters :
 >
 > **Several `ingress.tls` entries:** The chart also supports **multiple** `ingress.tls` items—Kubernetes allows mapping different `secretName` values to different `hosts` (e.g. one secret per public hostname). The rendered `Ingress` is valid; use this when your PKI or operations require per-host secrets. `spec.rules` hostnames still come from your `services` configuration, so keep `services.*.host` aligned with the certificates you use.
 
+#### Examples
+
+Minimal value fragments (merge with your own file). Hostnames and secret names are illustrative.
+
+**One `ingress.tls` entry — only `secretName`:** The chart fills `spec.tls[0].hosts` from `services.*.host` (and related settings).
+
+```yaml
+ingress:
+  enabled: true
+  tls:
+    - secretName: my-tls
+services:
+  webapp:
+    host: myapp.example.com
+  api:
+    host: myapi.example.com
+  api-v4:
+    host: myapi.example.com
+  files:
+    host: myfiles.example.com
+domain: .example.com
+```
+
+**One `ingress.tls` entry — `secretName` plus explicit `hosts`:** Use when a single certificate lists the names explicitly (SAN / wildcard).
+
+```yaml
+ingress:
+  enabled: true
+  tls:
+    - secretName: cert-tls
+      hosts:
+        - cert-host-one.example.com
+        - cert-host-two.example.com
+```
+
+**Several `ingress.tls` entries — one secret per hostname:**
+
+```yaml
+ingress:
+  enabled: true
+  tls:
+    - hosts:
+        - app.mycompany.com
+      secretName: neoload-web-tls
+    - hosts:
+        - api.mycompany.com
+      secretName: neoload-api-tls
+    - hosts:
+        - files.mycompany.com
+      secretName: neoload-files-tls
+services:
+  webapp:
+    host: app.mycompany.com
+  api:
+    host: api.mycompany.com
+  api-v4:
+    host: api.mycompany.com
+  files:
+    host: files.mycompany.com
+domain: .mycompany.com
+```
+
 #### Using an existing TLS secret
 
 Simply refer to your secret in the `ingress.tls[0].secretName` parameter, and leave both `ingress.tls[0].secretCertificate` and `ingress.tls[0].secretKey` empty.

--- a/README.md
+++ b/README.md
@@ -518,10 +518,12 @@ If you want to secure NeoLoad Web through TLS, you should either:
 To enable TLS and access NeoLoad Web via https, the parameters :
 
 - `ingress.enabled` must be true
-- `ingress.tls` must contain at least one item with the tls secret data
+- `ingress.tls` must contain at least one item with the TLS secret data (or references to it)
 
-> [!CAUTION]
-> Ingresses support multiple TLS mapped to respective hosts and paths. This feature is not supported for NeoLoad Web, i.e. exactly zero or one TLS configuration is expected.
+> [!NOTE]
+> **Single TLS block (recommended):** Prefer **one** `ingress.tls` entry: either set `ingress.tls[0].secretName` and omit `hosts` (the chart fills `hosts` from `services`), or set one secret with a `hosts` list (or a wildcard / SAN certificate). This is the simplest to operate and matches most deployments.
+>
+> **Several `ingress.tls` entries:** The chart also supports **multiple** `ingress.tls` items—Kubernetes allows mapping different `secretName` values to different `hosts` (e.g. one secret per public hostname). The rendered `Ingress` is valid; use this when your PKI or operations require per-host secrets. `spec.rules` hostnames still come from your `services` configuration, so keep `services.*.host` aligned with the certificates you use.
 
 #### Using an existing TLS secret
 

--- a/tests/ingress-annotations_test.yaml
+++ b/tests/ingress-annotations_test.yaml
@@ -135,7 +135,6 @@ tests:
           path: spec.tls[0].hosts
           content: cert-host-two.example.com
 
-  # Per-host TLS secrets (one spec.tls[] entry per secret); see README (Ingress TLS termination).
   - it: should render valid Ingress with multiple tls entries and per-host secrets
     release:
       namespace: default

--- a/tests/ingress-annotations_test.yaml
+++ b/tests/ingress-annotations_test.yaml
@@ -79,6 +79,8 @@ tests:
       - equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
           value: "500m"
+      - notExists:
+          path: spec.tls
 
   - it: should render valid Ingress when ingress.tls has only secretName (auto hosts, SWAT-9562)
     release:
@@ -97,6 +99,110 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: my-tls
+      - lengthEqual:
+          path: spec.tls[0].hosts
+          count: 4
+
+  - it: should render valid Ingress when ingress.tls has explicit hosts list
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.api-v4.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress:
+        enabled: true
+        tls:
+          - secretName: cert-tls
+            hosts:
+              - cert-host-one.example.com
+              - cert-host-two.example.com
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.tls[0].secretName
+          value: cert-tls
+      - lengthEqual:
+          path: spec.tls[0].hosts
+          count: 2
+      - contains:
+          path: spec.tls[0].hosts
+          content: cert-host-one.example.com
+      - contains:
+          path: spec.tls[0].hosts
+          content: cert-host-two.example.com
+
+  # Per-host TLS secrets (one spec.tls[] entry per secret); see README (Ingress TLS termination).
+  - it: should render valid Ingress with multiple tls entries and per-host secrets
+    release:
+      namespace: default
+    set:
+      services.webapp.host: app.mycompany.com
+      services.api.host: api.mycompany.com
+      services.api-v4.host: api.mycompany.com
+      services.files.host: files.mycompany.com
+      domain: .mycompany.com
+      ingress:
+        enabled: true
+        tls:
+          - hosts:
+              - app.mycompany.com
+            secretName: neoload-web-tls
+          - hosts:
+              - api.mycompany.com
+            secretName: neoload-api-tls
+          - hosts:
+              - files.mycompany.com
+            secretName: neoload-files-tls
+    asserts:
+      - isKind:
+          of: Ingress
+      - lengthEqual:
+          path: spec.tls
+          count: 3
+      - equal:
+          path: spec.tls[0].secretName
+          value: neoload-web-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: app.mycompany.com
+      - equal:
+          path: spec.tls[1].secretName
+          value: neoload-api-tls
+      - equal:
+          path: spec.tls[1].hosts[0]
+          value: api.mycompany.com
+      - equal:
+          path: spec.tls[2].secretName
+          value: neoload-files-tls
+      - equal:
+          path: spec.tls[2].hosts[0]
+          value: files.mycompany.com
+
+  - it: should render valid Ingress with ingressClassName and TLS secretName only
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.api-v4.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.tls[0].secretName: combined-tls
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: traefik
+      - equal:
+          path: spec.tls[0].secretName
+          value: combined-tls
       - lengthEqual:
           path: spec.tls[0].hosts
           count: 4


### PR DESCRIPTION
## Follow-up to #98 (ingress TLS YAML fix)

### Tests (`tests/ingress-annotations_test.yaml`)
- Assert `spec.tls` is absent when TLS is not configured
- TLS with `secretName` only (auto hosts) — regression for SWAT-9562
- TLS with explicit `hosts` list (single `ingress.tls` entry)
- `ingressClassName` + TLS `secretName` only
- Multiple `ingress.tls` entries with per-host secrets (chart renders valid `Ingress`)

### Documentation (`README.md`)
- Replaces the previous **CAUTION** that stated only zero or one TLS block was allowed
- Documents **recommended** single TLS block vs **optional** multiple `ingress.tls` items (per-host secrets), aligned with what the chart renders and what `helm-unittest` covers

### Jira
https://tricentis.atlassian.net/browse/SWAT-9562

**Merge note:** Target base is `featuregroup/SWAT-9562` so this stacks on the first PR. After #98 merges to `master`, either merge this branch into the same target or change the PR base to `master` and rebase.