### PR TITLE
Add GitHub Actions workflow for helm lint and unittest on PRs

### DIFF
--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -1,0 +1,30 @@
+name: Helm chart checks
+
+on:
+  pull_request:
+
+concurrency:
+  group: helm-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+        with:
+          version: v3.18.4
+
+      - name: Install helm-unittest plugin
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
+
+      - name: Helm lint
+        run: helm lint .
+
+      - name: Helm unittest
+        run: helm unittest .

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -23,8 +23,11 @@ jobs:
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
 
-      - name: Helm lint
+      - name: Helm lint (example Kubernetes / Traefik values)
         run: helm lint . -f values-custom.yaml
+
+      - name: Helm lint (example OpenShift values)
+        run: helm lint . -f values-custom-openshift.yaml
 
       - name: Helm unittest
         run: helm unittest .

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -24,7 +24,7 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
 
       - name: Helm lint
-        run: helm lint .
+        run: helm lint . -f values-custom.yaml
 
       - name: Helm unittest
         run: helm unittest .

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,12 @@ services:
     ingress:
       paths: ["/"]
 
+### Ingress (disabled by default; see values-custom.yaml for a full example)
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+
 resources:
   backend:
     requests:

--- a/values.yaml
+++ b/values.yaml
@@ -68,12 +68,6 @@ services:
     ingress:
       paths: ["/"]
 
-### Ingress (disabled by default; see values-custom.yaml for a full example)
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-
 resources:
   backend:
     requests:


### PR DESCRIPTION
## Summary

- Add a pull request workflow that installs Helm (pinned binary `v3.18.4`), installs the helm-unittest plugin (`v1.0.3`), runs two `helm lint` passes (`values-custom.yaml` and `values-custom-openshift.yaml`), then `helm unittest .` from the chart root.
- Pin `actions/checkout` to **v6.0.2** (commit SHA) and `azure/setup-helm` to **v5** (commit SHA) for supply-chain consistency.
- Lint merges the example value files so templates are checked against the documented Kubernetes/Traefik and OpenShift paths without changing stock `values.yaml`. Helm unittest continues to cover more advanced scenarios.