### PR TITLE
LOAD-37379 - Auto-derive backend COOKIE_SECURE from chart TLS detection

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.1
+version: 3.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -618,6 +618,25 @@ NeoLoad Web gathers and sends data related to the usage of specific features and
 
 ## Troubleshooting
 
+### Login redirect loop on plain HTTP deployments
+
+If users land back on `/login?return=/` immediately after submitting valid credentials on a plain HTTP deployment, the backend session cookie is being issued with the `Secure` attribute, which browsers refuse to send back over HTTP.
+
+Since chart `3.0.2`, `COOKIE_SECURE` is derived automatically from the chart's TLS detection (see [Session cookies](./doc/advanced-configuration.md#session-cookies-cookie_secure)):
+
+- `ingress.tls` set, or `neoload.configuration.externalTlsTermination: true` → `COOKIE_SECURE=true`
+- otherwise → `COOKIE_SECURE=false`
+
+If you are on `3.0.0` or `3.0.1`, either upgrade to `3.0.2`+ or override manually:
+
+```yaml
+neoload:
+  configuration:
+    backend:
+      others:
+        COOKIE_SECURE: "false" # only on HTTP-only deployments
+```
+
 ### SSO error: "Size exceed allowed maximum capacity"
 
 If, during SSO authentication, the browser shows the error "Size exceed allowed maximum capacity", it likely means the default maximum size for HTTP form attributes (32768 bytes) is too low for your IdP's payload.

--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ NeoLoad Web gathers and sends data related to the usage of specific features and
 
 If users land back on `/login?return=/` immediately after submitting valid credentials on a plain HTTP deployment, the backend session cookie is being issued with the `Secure` attribute, which browsers refuse to send back over HTTP.
 
-Since chart `3.0.2`, `COOKIE_SECURE` is derived automatically from the chart's TLS detection (see [Session cookies](./doc/advanced-configuration.md#session-cookies-cookie_secure)):
+Since chart `3.0.2`, `COOKIE_SECURE` is derived automatically from the chart's TLS detection:
 
 - `ingress.tls` set, or `neoload.configuration.externalTlsTermination: true` → `COOKIE_SECURE=true`
 - otherwise → `COOKIE_SECURE=false`

--- a/doc/advanced-configuration.md
+++ b/doc/advanced-configuration.md
@@ -77,7 +77,7 @@ Parameter | Description | Default
 `neoload.configuration.backend.licensingPlatformTokenExistingSecret` | Name of an existing Secret containing the licensing platform token. Must have the key `licensingPlatformToken`. Takes precedence over `licensingPlatformToken`. | 
 `neoload.configuration.backend.livenessProbe.initDelaySeconds` | Backend Pods liveness probe initial delay in seconds | 60
 `neoload.configuration.backend.readinessProbe.initDelaySeconds` | Backend Pods readiness probe initial delay in seconds | 60
-`neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
+`neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) Notably, this is also the only way to override the auto-derived `COOKIE_SECURE` value (`COOKIE_SECURE: "true"` or `"false"`). |
 `neoload.configuration.backend.cors.additionalAllowedOriginPattern` | Additional CORS origin regex appended to base `scheme + ".*" + domain`. Example: `https://.*.okta.com` | 
 `neoload.configuration.backend.enableServiceLinks` | When set, sets the pod spec `enableServiceLinks` (e.g. `false` to avoid too many service env vars). See [Troubleshooting](../README.md#frontend-does-not-start--envsubst-argument-list-too-long). |
 | | 
@@ -156,6 +156,33 @@ Other examples:
 - Exact Okta tenant: `"https://my-tenant.okta.com"`
 - Keycloak single host: `"https://keycloak.example.com"`
 - Azure AD (example): `"https://login.microsoftonline.com"`
+
+## Session cookies (`COOKIE_SECURE`)
+
+The chart configures the backend's session cookie `Secure` attribute automatically based on the deployment's TLS state. The same signal that picks `http://` vs `https://` for the public URLs (`nlweb.helpers.getScheme`) is used to derive the `COOKIE_SECURE` env var injected into the backend Pod:
+
+| Deployment | `COOKIE_SECURE` |
+| --- | --- |
+| `ingress.enabled: true` and `ingress.tls` is set | `"true"` |
+| `neoload.configuration.externalTlsTermination: true` | `"true"` |
+| Plain HTTP (no `ingress.tls`, `externalTlsTermination` unset/false) | `"false"` |
+
+`Secure` cookies are required for HTTPS deployments and dropped by browsers on plain HTTP. Letting the chart derive this avoids the silent login redirect loop that occurs when a `Secure` cookie is issued over HTTP.
+
+### Overriding the default
+
+If you need to force a specific value (e.g. for an unusual reverse-proxy setup that performs TLS termination outside the chart's knowledge), set it explicitly under `neoload.configuration.backend.others`:
+
+```yaml
+neoload:
+  configuration:
+    backend:
+      others:
+        COOKIE_SECURE: "true"
+```
+
+> [!CAUTION]
+> Do not set `COOKIE_SECURE: "false"` on a TLS-enabled deployment.
 
 ## Side-car containers
 

--- a/doc/advanced-configuration.md
+++ b/doc/advanced-configuration.md
@@ -157,30 +157,6 @@ Other examples:
 - Keycloak single host: `"https://keycloak.example.com"`
 - Azure AD (example): `"https://login.microsoftonline.com"`
 
-## Session cookies (`COOKIE_SECURE`)
-
-The chart configures the backend's session cookie `Secure` attribute automatically based on the deployment's TLS state. The same signal that picks `http://` vs `https://` for the public URLs (`nlweb.helpers.getScheme`) is used to derive the `COOKIE_SECURE` env var injected into the backend Pod:
-
-| Deployment | `COOKIE_SECURE` |
-| --- | --- |
-| `ingress.enabled: true` and `ingress.tls` is set | `"true"` |
-| `neoload.configuration.externalTlsTermination: true` | `"true"` |
-| Plain HTTP (no `ingress.tls`, `externalTlsTermination` unset/false) | `"false"` |
-
-`Secure` cookies are required for HTTPS deployments and dropped by browsers on plain HTTP. Letting the chart derive this avoids the silent login redirect loop that occurs when a `Secure` cookie is issued over HTTP.
-
-### Overriding the default
-
-If you need to force a specific value (e.g. for an unusual reverse-proxy setup that performs TLS termination outside the chart's knowledge), set it explicitly under `neoload.configuration.backend.others`:
-
-```yaml
-neoload:
-  configuration:
-    backend:
-      others:
-        COOKIE_SECURE: "true"
-```
-
 ## Side-car containers
 
 > [!CAUTION]

--- a/doc/advanced-configuration.md
+++ b/doc/advanced-configuration.md
@@ -77,7 +77,7 @@ Parameter | Description | Default
 `neoload.configuration.backend.licensingPlatformTokenExistingSecret` | Name of an existing Secret containing the licensing platform token. Must have the key `licensingPlatformToken`. Takes precedence over `licensingPlatformToken`. | 
 `neoload.configuration.backend.livenessProbe.initDelaySeconds` | Backend Pods liveness probe initial delay in seconds | 60
 `neoload.configuration.backend.readinessProbe.initDelaySeconds` | Backend Pods readiness probe initial delay in seconds | 60
-`neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) Notably, this is also the only way to override the auto-derived `COOKIE_SECURE` value (`COOKIE_SECURE: "true"` or `"false"`). |
+`neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
 `neoload.configuration.backend.cors.additionalAllowedOriginPattern` | Additional CORS origin regex appended to base `scheme + ".*" + domain`. Example: `https://.*.okta.com` | 
 `neoload.configuration.backend.enableServiceLinks` | When set, sets the pod spec `enableServiceLinks` (e.g. `false` to avoid too many service env vars). See [Troubleshooting](../README.md#frontend-does-not-start--envsubst-argument-list-too-long). |
 | | 
@@ -180,9 +180,6 @@ neoload:
       others:
         COOKIE_SECURE: "true"
 ```
-
-> [!CAUTION]
-> Do not set `COOKIE_SECURE: "false"` on a TLS-enabled deployment.
 
 ## Side-car containers
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -132,11 +132,26 @@ Helper - stringToStrings
 {{- end -}}
 
 {{/*
+Helper - tlsEnabled
+Returns the string "true" when the deployment is TLS-terminated, "false" otherwise.
+TLS is considered enabled when either:
+  - the chart-managed Ingress is enabled and `ingress.tls` is set, or
+  - `neoload.configuration.externalTlsTermination` is set to "true" (TLS handled in front of the Ingress controller).
+*/}}
+{{- define "nlweb.helpers.tlsEnabled" -}}
+    {{- if or (and .Values.ingress.enabled .Values.ingress.tls) (eq (.Values.neoload.configuration.externalTlsTermination | toString) "true") -}}
+        true
+    {{- else -}}
+        false
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Helper - getScheme
 */}}
 {{- define "nlweb.helpers.getScheme" -}}
     http
-    {{- if or (and .Values.ingress.enabled .Values.ingress.tls) (eq (.Values.neoload.configuration.externalTlsTermination | toString) "true") -}}
+    {{- if eq (include "nlweb.helpers.tlsEnabled" .) "true" -}}
         s
     {{- end -}}
     ://

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -158,6 +158,16 @@ spec:
             - name: COOKIE_DOMAIN
               value: {{ (.Values.domain | required "NeoLoad Web domain (.Values.domain) value is required." ) | quote }}
             {{- end }}
+            {{- /*
+              Derive COOKIE_SECURE from the chart's TLS detection (same signal as nlweb.helpers.getScheme):
+                - TLS-terminated deployments  -> "true"  (Secure cookies, required for HTTPS)
+                - Plain HTTP deployments      -> "false" (browsers drop Secure cookies on HTTP, breaking login)
+              Users can still override by setting `neoload.configuration.backend.others.COOKIE_SECURE`.
+            */ -}}
+            {{- if or (not .Values.neoload.configuration.backend.others) (not (hasKey .Values.neoload.configuration.backend.others "COOKIE_SECURE")) }}
+            - name: COOKIE_SECURE
+              value: {{ include "nlweb.helpers.tlsEnabled" . | quote }}
+            {{- end }}
           ports:
             - name: api
               containerPort: 1081

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -158,12 +158,6 @@ spec:
             - name: COOKIE_DOMAIN
               value: {{ (.Values.domain | required "NeoLoad Web domain (.Values.domain) value is required." ) | quote }}
             {{- end }}
-            {{- /*
-              Derive COOKIE_SECURE from the chart's TLS detection (same signal as nlweb.helpers.getScheme):
-                - TLS-terminated deployments  -> "true"  (Secure cookies, required for HTTPS)
-                - Plain HTTP deployments      -> "false" (browsers drop Secure cookies on HTTP, breaking login)
-              Users can still override by setting `neoload.configuration.backend.others.COOKIE_SECURE`.
-            */ -}}
             {{- if or (not .Values.neoload.configuration.backend.others) (not (hasKey .Values.neoload.configuration.backend.others "COOKIE_SECURE")) }}
             - name: COOKIE_SECURE
               value: {{ include "nlweb.helpers.tlsEnabled" . | quote }}

--- a/tests/deployment-back_test.yaml
+++ b/tests/deployment-back_test.yaml
@@ -40,7 +40,7 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers[0].env
-          count: 28
+          count: 29
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -182,6 +182,12 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: COOKIE_SECURE
+            value: "false"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: MONGODB_HOST
             valueFrom:
               secretKeyRef:
@@ -224,5 +230,75 @@ tests:
                 name: RELEASE-NAME-nlweb-key-secret
                 key: internalTokenSecret
           any: true
-      
 
+  - it: should set COOKIE_SECURE=true when ingress.tls is configured
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: my-tls-secret
+      neoload.configuration.backend.mongo.host: mymongo.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COOKIE_SECURE
+            value: "true"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEOLOAD_WEB_PUBLIC_URL
+            value: "https://myapp.example.com"
+          any: true
+
+  - it: should set COOKIE_SECURE=true when externalTlsTermination is true
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: false
+      neoload.configuration.externalTlsTermination: true
+      neoload.configuration.backend.mongo.host: mymongo.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COOKIE_SECURE
+            value: "true"
+          any: true
+
+  - it: should let users override COOKIE_SECURE via neoload.configuration.backend.others
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: my-tls-secret
+      neoload.configuration.backend.mongo.host: mymongo.example.com
+      neoload.configuration.backend.others.COOKIE_SECURE: "false"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COOKIE_SECURE
+            value: "false"
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COOKIE_SECURE
+            value: "true"
+          any: true


### PR DESCRIPTION
## Summary

Fixes the silent login redirect loop on plain HTTP deployments introduced in chart `3.0.0` / `3.0.1` (`appVersion 2026.1.0`).

The 2026.1.0 backend now defaults `COOKIE_SECURE=true` when not set, so the session cookie is emitted with the `Secure` attribute. On HTTP-only deployments browsers refuse to send the cookie back, the session is never established, and the user is bounced to `/login?return=/`.

The chart already detects TLS via `nlweb.helpers.getScheme` (`ingress.tls` set, or `externalTlsTermination=true`) for the public URLs. This PR reuses that same signal to automatically default `COOKIE_SECURE` on the backend Deployment, while preserving the user override path (`neoload.configuration.backend.others.COOKIE_SECURE`) — same pattern already used for `COOKIE_DOMAIN`.

### Changes

- New helper `nlweb.helpers.tlsEnabled` in `templates/_helpers.tpl`; `getScheme` refactored to reuse it (DRY).
- `templates/deployment-back.yaml`: inject `COOKIE_SECURE` derived from the helper, only when the user hasn't set it under `others`.
- Chart version bumped `3.0.1` → `3.0.2`.
- `tests/deployment-back_test.yaml`: existing default suite now expects `COOKIE_SECURE: "false"` (HTTP-only); 3 new test cases cover `ingress.tls`, `externalTlsTermination`, and user override scenarios.
- `doc/advanced-configuration.md`: new "Session cookies (`COOKIE_SECURE`)" section with a truth table and override example.
- `README.md`: new Troubleshooting entry for users still on `3.0.0` / `3.0.1`.

### Behavior

| Scenario | `COOKIE_SECURE` |
| --- | --- |
| `ingress.tls` set | `"true"` |
| `externalTlsTermination: true` | `"true"` |
| Plain HTTP (no `ingress.tls`, `externalTlsTermination` unset/false) | `"false"` |
| User-set `others.COOKIE_SECURE` | user value wins |

### Backwards compatibility

- HTTPS deployments: behavior unchanged.
- HTTP deployments: now work out of the box (the regression fix).
- Anyone who already applied the manual workaround under `neoload.configuration.backend.others.COOKIE_SECURE` keeps working — that override path is preserved and takes precedence.

## Test plan

- [x] `helm unittest .` — 48/48 passing locally
- [x] `helm lint . -f values-custom.yaml` — clean
- [x] `helm lint . -f values-custom-openshift.yaml` — clean
- [x] `helm template` smoke-checked for HTTP, `ingress.tls`, `externalTlsTermination`, and user-override scenarios — produces expected `COOKIE_SECURE` and matching `http://` / `https://` URLs in each case
- [x] CI (`Helm chart checks`) green on this PR

## Jira

[LOAD-37379](https://tricentis.atlassian.net/browse/LOAD-37379)

Made with [Cursor](https://cursor.com)