### PR TITLE
LOAD-38205: [NLW OnPremise NextGen] Support short service names to bypass upstream DNS forwarding issues

### DIFF
--- a/doc/advanced-configuration.md
+++ b/doc/advanced-configuration.md
@@ -77,6 +77,7 @@ Parameter | Description | Default
 `neoload.configuration.backend.licensingPlatformTokenExistingSecret` | Name of an existing Secret containing the licensing platform token. Must have the key `licensingPlatformToken`. Takes precedence over `licensingPlatformToken`. | 
 `neoload.configuration.backend.livenessProbe.initDelaySeconds` | Backend Pods liveness probe initial delay in seconds | 60
 `neoload.configuration.backend.readinessProbe.initDelaySeconds` | Backend Pods readiness probe initial delay in seconds | 60
+`neoload.configuration.backend.useFqdn` | Set to `false` to use short service names instead of FQDNs to avoid upstream DNS resolution issues in restricted environments | `true`
 `neoload.configuration.backend.others` | Custom backend environment variables. [Learn more.](#custom-environment-variables) |
 `neoload.configuration.backend.cors.additionalAllowedOriginPattern` | Additional CORS origin regex appended to base `scheme + ".*" + domain`. Example: `https://.*.okta.com` | 
 `neoload.configuration.backend.enableServiceLinks` | When set, sets the pod spec `enableServiceLinks` (e.g. `false` to avoid too many service env vars). See [Troubleshooting](../README.md#frontend-does-not-start--envsubst-argument-list-too-long). |

--- a/templates/deployment-back.yaml
+++ b/templates/deployment-back.yaml
@@ -101,13 +101,21 @@ spec:
             - name: NEOLOAD_WEB_PUBLIC_URL_NEXT_GEN
               value: {{ printf "%s%s/public" (include "nlweb.helpers.getScheme" .) (include "nlweb.webapp.host" .) | required "NeoLoad Web Public URL (.Values.services.webapp.host) value is required." | quote }}
             - name: NEOLOAD_WEB_PUBLIC_URL_NEXT_GEN_KUB
+              {{- if .Values.neoload.configuration.backend.useFqdn }}
               value: "http://{{ include "nlweb.fullname" . }}-svc-webapp.{{ .Release.Namespace }}.svc.cluster.local/public"
+              {{- else }}
+              value: "http://{{ include "nlweb.fullname" . }}-svc-webapp.{{ .Release.Namespace }}/public"
+              {{- end }}
             - name: NEOLOAD_WEB_API_PUBLIC_URL
               value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (include "nlweb.api.host" .) | required "NeoLoad Web API URL (.Values.services.api.host) value is required." | quote }}
             - name: FILE_STORAGE_ROUTER_BASE_URL
               value: {{ printf "%s%s" (include "nlweb.helpers.getScheme" .) (include "nlweb.files.host" .) | required "NeoLoad Web Files API URL (.Values.services.files.host) value is required." | quote }}
             - name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
+              {{- if .Values.neoload.configuration.backend.useFqdn }}
               value: "http://{{ include "nlweb.fullname" . }}-svc-files.{{ .Release.Namespace }}.svc.cluster.local"              
+              {{- else }}
+              value: "http://{{ include "nlweb.fullname" . }}-svc-files.{{ .Release.Namespace }}"              
+              {{- end }}
             - name: FILE_PROJECT_MAX_SIZE_IN_BYTES
               value: {{ int .Values.neoload.configuration.backend.misc.files.maxUploadSizeInBytes | quote }}
             - name: MAX_FORM_ATTRIBUTE_SIZE

--- a/tests/deployment-back_test.yaml
+++ b/tests/deployment-back_test.yaml
@@ -308,3 +308,53 @@ tests:
             name: COOKIE_SECURE
             value: "true"
           any: true
+
+  - it: should generate short service names when useFqdn is false
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: false
+      neoload.configuration.backend.mongo.host: mymongo.example.com
+      neoload.configuration.backend.useFqdn: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEOLOAD_WEB_PUBLIC_URL_NEXT_GEN_KUB
+            value: "http://RELEASE-NAME-nlweb-svc-webapp.default/public"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
+            value: "http://RELEASE-NAME-nlweb-svc-files.default"
+          any: true
+
+  - it: should generate FQDN service names when useFqdn is true
+    release:
+      namespace: default
+    set:
+      services.webapp.host: myapp.example.com
+      services.api.host: myapi.example.com
+      services.files.host: myfiles.example.com
+      domain: .example.com
+      ingress.enabled: false
+      neoload.configuration.backend.mongo.host: mymongo.example.com
+      neoload.configuration.backend.useFqdn: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEOLOAD_WEB_PUBLIC_URL_NEXT_GEN_KUB
+            value: "http://RELEASE-NAME-nlweb-svc-webapp.default.svc.cluster.local/public"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
+            value: "http://RELEASE-NAME-nlweb-svc-files.default.svc.cluster.local"
+          any: true

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,10 @@ neoload:
     backendUtilities: {}
   configuration:
     backend:
+      # Set to false to use short service names (e.g. svc-name.namespace)
+      # instead of FQDN (e.g. svc-name.namespace.svc.cluster.local)
+      # to avoid upstream DNS resolution issues in some environments.
+      useFqdn: true
       mongo:
         host: 
         port: 27017


### PR DESCRIPTION
## Summary
- Introduces a new boolean configuration option `neoload.configuration.backend.useFqdn` (default `true`) in `values.yaml`.
- Conditionally generates short service names (`http://<fullname>-svc-webapp.<namespace>/public` and `http://<fullname>-svc-files.<namespace>`) instead of fully qualified domain names (FQDNs) when `useFqdn` is set to `false`.
- Bypasses upstream DNS resolution and forwarding issues in restricted customer Kubernetes environments where `.local` or `.cluster.local` queries are dropped or intercepted by corporate DNS firewalls.

## Test plan
- Added unit tests in `tests/deployment-back_test.yaml` to verify both `useFqdn: false` and `useFqdn: true` behaviors.
- Ran all unit tests using `helm unittest ./` and verified they all pass.

Made with [Cursor](https://cursor.com)