### PR TITLE
LOAD-38244: [NLW OnPremise NextGen] CORS allowed origin pattern does not respect useFqdn option

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -280,7 +280,12 @@ Returns a single-line string combining scheme+domain and optional additional pat
 */}}
 {{- define "nlweb.helpers.corsAllowedOriginPattern" -}}
     {{- $base := (printf "%s.*%s" (include "nlweb.helpers.getScheme" .) (.Values.domain) | required "NeoLoad Web domain (.Values.domain) value is required.") -}}
-    {{- $internalWebapp := printf "http://%s-svc-webapp.%s.svc.cluster.local" (include "nlweb.fullname" .) .Release.Namespace -}}
+    {{- $internalWebapp := "" -}}
+    {{- if .Values.neoload.configuration.backend.useFqdn -}}
+        {{- $internalWebapp = printf "http://%s-svc-webapp.%s.svc.cluster.local" (include "nlweb.fullname" .) .Release.Namespace -}}
+    {{- else -}}
+        {{- $internalWebapp = printf "http://%s-svc-webapp.%s" (include "nlweb.fullname" .) .Release.Namespace -}}
+    {{- end -}}
     {{- $cors := (default dict .Values.neoload.configuration.backend.cors) -}}
     {{- if $cors.additionalAllowedOriginPattern -}}
         {{- printf "%s,%s,%s" $base $internalWebapp $cors.additionalAllowedOriginPattern -}}

--- a/tests/deployment-back_test.yaml
+++ b/tests/deployment-back_test.yaml
@@ -333,6 +333,12 @@ tests:
             name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
             value: "http://RELEASE-NAME-nlweb-svc-files.default"
           any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CORS_ALLOWED_ORIGIN_PATTERN
+            value: "http://.*.example.com,http://RELEASE-NAME-nlweb-svc-webapp.default"
+          any: true
 
   - it: should generate FQDN service names when useFqdn is true
     release:
@@ -357,4 +363,10 @@ tests:
           content:
             name: INTERNAL_FILE_STORAGE_ROUTER_BASE_URL
             value: "http://RELEASE-NAME-nlweb-svc-files.default.svc.cluster.local"
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CORS_ALLOWED_ORIGIN_PATTERN
+            value: "http://.*.example.com,http://RELEASE-NAME-nlweb-svc-webapp.default.svc.cluster.local"
           any: true


### PR DESCRIPTION
## Summary
- Fixes a bug where the CORS allowed origin pattern `nlweb.helpers.corsAllowedOriginPattern` remained hardcoded to the FQDN (`http://<fullname>-svc-webapp.<namespace>.svc.cluster.local`) even when `neoload.configuration.backend.useFqdn` was set to `false`.
- Conditionally uses the short service name (`http://<fullname>-svc-webapp.<namespace>`) in the CORS allowed origin pattern when `useFqdn` is `false`.

## Test plan
- Updated unit tests in `tests/deployment-back_test.yaml` to verify `CORS_ALLOWED_ORIGIN_PATTERN` matches the expected short name when `useFqdn` is `false`, and the FQDN when `useFqdn` is `true`.
- Ran all unit tests using `helm unittest ./` and verified they all pass.

Made with [Cursor](https://cursor.com)