### PR TITLE
Bump version to 3.0.5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,11 +13,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.4
+version: 3.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "2026.1.1"
+appVersion: "2026.1.2"
 
 home: https://www.neotys.com/neoload
 description: A Helm chart for deploying NeoLoad Web on Kubernetes

--- a/doc/technical-release-notes/NeoLoad Web 2026.1.X Technical Release Notes.txt
+++ b/doc/technical-release-notes/NeoLoad Web 2026.1.X Technical Release Notes.txt
@@ -12,3 +12,7 @@ NeoLoad Web 2026.1.1 Technical Release Notes
 [LOAD-36989] - Fixed the zones settings drawer. A scrollbar now appears when a zone lists many Load Generators. You can view the full list without zooming out the browser.
 [LOAD-37338] - Fixed legend truncation in dashboard PDF exports. Series tiles with many curves now show all curve labels.
 [LOAD-37429] - Fixed an error that prevented PDF export of comparison dashboards. All exports now complete successfully.
+
+NeoLoad Web 2026.1.2 Technical Release Notes
+
+[LOAD-38254] - Bundle Inter font locally to support restricted network environments


### PR DESCRIPTION
## Summary

- Bump version to 3.0.5 and appVersion to 2026.1.2 in `Chart.yaml` to prepare for the next release.

Made with [Cursor](https://cursor.com)